### PR TITLE
Adding option to suppress user data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: audit.connect
 Title: Posit Connect Health Check
-Version: 0.6.3
+Version: 0.7.0
 Authors@R:
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: Posit Connect Health Check. Deploys various content types to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# audit.connect 0.7.0 _2023-10-03_
+ - feat: Add option to suppress collection of Connect users' data
+
 # audit.connect 0.6.4 _2023-10-01_
  - feat: Check for Posit name leakage
  

--- a/R/check.R
+++ b/R/check.R
@@ -17,7 +17,8 @@
 #' @export
 check = function(server = NULL, token = NULL,
                  dir = ".",
-                 debug_level = 0:2) {
+                 debug_level = 0:2,
+                 suppress_users = FALSE) {
 
   debug_level = get_debug_level(force(debug_level))
   check_list = list()
@@ -31,9 +32,10 @@ check = function(server = NULL, token = NULL,
 
   check_list$feature_usage = summarise_feature_usage(get_server(), get_token())
   check_list$audit_details = audit_details(get_server(), get_token())
-  check_list$users_details = summarise_users(get_server(), get_token(), debug_level = debug_level)
+  if(!suppress_users){
+    check_list$users_details = summarise_users(get_server(), get_token(), debug_level = debug_level) 
+  }
   register_uat_user(get_server(), get_token(), account = get_account())
-
   check_list$results = check_deployments(dir, debug_level)
   cli::cli_h1("All checks complete")
   invisible(check_list)


### PR DESCRIPTION
This adds a `suppress_users` boolean parameter to the `audit.connect::check` function.
By default, `suppress_users` is `FALSE` -- that is user data isn't suppressed.

However, when `suppress_users` is set to `TRUE`, then the user data is suppressed.

# Testing
```r
CONNECT_API_TOKEN = ""
CONNECT_SERVER_URL = "https://rsc.jumpingrivers.cloud/"

# With this code, audit_connect_object has a field audit_connect_object$users_details
audit_connect_object = audit.connect::check(server = CONNECT_SERVER_URL,token = CONNECT_API_TOKEN)
audit_connect_object

# When suppress_users=TRUE, then it doesn't have that field audit_connect_object_no_users$users_details
audit_connect_object_no_users = audit.connect::check(server = CONNECT_SERVER_URL,token = CONNECT_API_TOKEN, suppress_users=TRUE)
audit_connect_object_no_users
```