### PR TITLE
feat: Force `server` to have `http(?s)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: audit.connect
 Title: Posit Connect Health Check
-Version: 0.7.3
+Version: 0.7.4
 Authors@R:
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: Posit Connect Health Check. Deploys various content types to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
+# audit.connect 0.7.4 _2024-04-04_
+  - feat: Force `server` to have `http(?s)`
+  - feat: Improved error message when testing status response
+
 # audit.connect 0.7.3 _2024-03-27_
   - fix: Remove additional / from user api call
-
+  
 # audit.connect 0.7.2 _2024-01-24_
   - fix: If NA, return 0 locked apps
 

--- a/R/audit_details.R
+++ b/R/audit_details.R
@@ -1,3 +1,4 @@
+
 audit_details = function(server, token) {
   user_details = summarise_user(server, token)
   c(user_details,
@@ -12,6 +13,7 @@ summarise_user = function(server, token) {
   cli::cli_h2("User Summary")
   res = httr::GET(paste0(server, "__api__/v1/user"),
                   httr::add_headers(Authorization = paste("Key", token)))
+
   check_api_status_code(res)
   content = httr::content(res)
   cli::cli_alert_info("{content$first_name} {content$last_name} <{content$email}>")
@@ -29,6 +31,7 @@ check_api_status_code = function(res) {
     cli::cli_alert_danger("Likely causes are: bad token or bad server URL")
     cli::cli_alert_danger("{res$url} has status code {status}")
     cli::cli_alert_danger("{httr::http_status(status)$message}")
+    cli::cli_alert_danger("You could try changing http <-> https in the server URL")
     cli::cli_abort("Status code: {status}")
   }
   return(invisible(NULL))

--- a/R/summarise_setup.R
+++ b/R/summarise_setup.R
@@ -32,9 +32,12 @@ standardise_server_url = function(server) {
     server = paste0(server, "/")
   }
 
+  # We need to enforce adding http, otherwise things get messy. E.g.
+  # APIs typically need SSL, but if we only have http, that's "OK" to use http.
+  # But if we try http, and https is needed, it fails.
   start_address = stringr::str_starts(server, pattern = "http")
   if (isFALSE(start_address)) {
-    server = paste0("http://", server)
+    cli::cli_abort("Please add https (or http) to the server URL.")
   }
   cli::cli_alert_info("Server: {cli::col_green(server)}")
   return(invisible(server))


### PR DESCRIPTION
  -  feat: Force `server` to have `http(?s)`
  - feat: Improved error message when testing status response