### PR TITLE
Use magrittr pipe for older R versions (#42)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: audit.connect
 Title: Posit Connect Health Check
-Version: 0.7.7
+Version: 0.7.8
 Authors@R:
     person("Jumping", "Rivers", , "info@jumpingrivers.com", role = c("aut", "cre"))
 Description: Posit Connect Health Check. Deploys various content types to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# audit.connect 0.7.8 _2025-07-30_
+  - fix: Use magrittr pipe for compatibility with older R versions.
+
 # audit.connect 0.7.7 _2025-07-16_
   - chore: Update requirements.txt
 

--- a/R/summarise_users.R
+++ b/R/summarise_users.R
@@ -58,15 +58,15 @@ print_audit_users = function(user_list) {
 print_audit_user_apps = function(client, debug_level) {
   suppress = get_suppress(debug_level)
   content = suppress(connectapi::get_content(client))
-  locked_users = suppress(connectapi::get_users(client)) |>
+  locked_users = suppress(connectapi::get_users(client)) %>%
     dplyr::filter(.data$locked)
   locked_content = dplyr::inner_join(
     content,
     locked_users,
     by = dplyr::join_by("owner_guid" == "guid")
-  ) |>
-    dplyr::group_by(.data$username) |>
-    dplyr::summarise(n = dplyr::n()) |>
+  ) %>%
+    dplyr::group_by(.data$username) %>%
+    dplyr::summarise(n = dplyr::n()) %>%
     dplyr::arrange(dplyr::desc(.data$n))
 
   cli::cli_alert_info(


### PR DESCRIPTION
Closes #42 

Decided to convert `|>` to `%>%` for consistency with all other pipes in the package. It also maintains compatibility pre-R 4.1.